### PR TITLE
Time elapsed/remaining for jupyter

### DIFF
--- a/atpbar/main.py
+++ b/atpbar/main.py
@@ -1,13 +1,14 @@
 # Tai Sakuma <tai.sakuma@gmail.com>
 import os, uuid
 import logging
+import time
 
 import contextlib
 
 from .funcs import fetch_reporter, in_main_thread
 
 ##__________________________________________________________________||
-def atpbar(iterable, name=None):
+def atpbar(iterable, name=None, time_track=False):
     """returns an instance of `Atpbar`
 
     Parameters
@@ -35,7 +36,7 @@ def atpbar(iterable, name=None):
     if name is None:
         name = repr(iterable)
 
-    return Atpbar(iterable, name=name, len_=len_)
+    return Atpbar(iterable, name=name, len_=len_, time_track=time_track)
 
 ##__________________________________________________________________||
 class Atpbar(object):
@@ -56,11 +57,12 @@ class Atpbar(object):
 
     """
 
-    def __init__(self, iterable, name, len_):
+    def __init__(self, iterable, name, len_, time_track=False):
         self.iterable = iterable
         self.name = name
         self.len_ = len_
         self.id_ = uuid.uuid4()
+        self.time_track = time_track
 
     def __iter__(self):
         with fetch_reporter() as reporter:
@@ -82,6 +84,8 @@ class Atpbar(object):
                 taskid=self.id_, name=self.name,
                 done=0, total=self.len_,
                 pid=os.getpid(), in_main_thread=in_main_thread())
+            if self.time_track:
+                report['start_time'] = start_time=time.time()
             self.reporter.report(report)
         except:
             pass

--- a/atpbar/presentation/barjupyter.py
+++ b/atpbar/presentation/barjupyter.py
@@ -82,7 +82,11 @@ class ProgressBarJupyter(Presentation):
         bar = (':' * int(percent * 40)).ljust(40, " ")
         percent = round(percent * 100, 2)
         name = report['name'][0:name_field_length]
-        label.value = '<pre> | {:8d} / {:8d} |:  {:<{}s}</pre>'.format(report['done'], report['total'], name, name_field_length)
+        if 'start_time' in report.keys():
+            elapsed_str, remaining_str = self._get_time_track(report['start_time'], percent)
+            label.value = '<pre> | {:8d} / {:8d}  ({:s} / {:s}) |: {:<{}s}</pre>'.format(report['done'], report['total'], elapsed_str, remaining_str, name, name_field_length)
+        else:
+            label.value = '<pre> | {:8d} / {:8d} |: {:<{}s}</pre>'.format(report['done'], report['total'], name, name_field_length)
 
     def _reorder_widgets(self, report):
         for taskid in self._finishing_taskids:

--- a/atpbar/presentation/base.py
+++ b/atpbar/presentation/base.py
@@ -98,4 +98,24 @@ class Presentation(object):
     def _read_time(self):
         self.last_time = self._time()
 
+    def _get_time_track(self, start_time, percent):
+        """Format seconds as hours, minutes and seconds.
+        """
+        time_elapsed = self._time() - start_time
+        time_remaining = (time_elapsed * (100/percent)) - time_elapsed if percent > 0 else 0
+
+        return self._time_to_str(time_elapsed), self._time_to_str(time_remaining)
+    
+    def _time_to_str(self, t):
+        mins = t // 60
+        s = int(t % 60)
+        
+        h = int(mins // 60)
+        m = int(mins % 60)
+
+        if h:
+            return '{0:d}:{1:02d}:{2:02d}'.format(h, m, s)
+        else:
+            return '{0:02d}:{1:02d}'.format(m, s)
+
 ##__________________________________________________________________||


### PR DESCRIPTION
I took the liberty to make some changes in order to implement the elapsed/remaining time (with regards to issue #12 ). I only made the changes for jupyter progress bar, but the elapsed/remaining method is in the `base.py` module, so the implementation should be easy for every other progress bar type. 

If you find these changes useful, please consider merging my code.