### PR TITLE
Update README code example for multiprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ def run_with_multiprocessing():
         queue.put((n, name))
     for i in range(nprocesses):
         queue.put(None)
-        queue.join()
+    queue.join()
     flush()
 
 run_with_multiprocessing()


### PR DESCRIPTION
`queue.join` does not need to be in the loop
https://docs.python.org/3/library/multiprocessing.html#multiprocessing.JoinableQueue.join