### PR TITLE
fix: chain `pypi.yml` from changelog workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,13 +1,11 @@
 name: Upload to PyPI
 
-# Build and publish to PyPI after "Release a new version" succeeds.
-# Triggered via workflow_run because the v-tag is pushed by GITHUB_TOKEN
-# in the changelog workflow, which does not trigger downstream `push tags`
-# or `release` events.
+# Publish to PyPI after the "Generate changelog" workflow succeeds.
+# This is part of the two-tag release flow (see changelog.yml).
 
 on:
   workflow_run:
-    workflows: ["Release a new version"]
+    workflows: ["Generate changelog"]
     types: [completed]
 
 jobs:
@@ -17,9 +15,10 @@ jobs:
     environment: pypi
     permissions:
       id-token: write
-      contents: read
+
     steps:
       - name: Checkout release tag
+        id: version
         uses: TaiSakuma/checkout-version-tag@v1
         with:
           trigger-tag: ${{ github.event.workflow_run.head_branch }}


### PR DESCRIPTION
## Summary

When `Upload to PyPI` is triggered by `Release a new version` (two hops from the originating tag push), `workflow_run.head_branch` is `main`, not the `u*` tag. `checkout-version-tag` then rejects the input — `Upload to PyPI` failed for v2.0.9.

Switch the trigger of `pypi.yml` to `Generate changelog` so the workflow stays one hop from the tag push and `head_branch` carries `u<version>`.

`pypi.yml` is now byte-identical to scikit-hep/hypothesis-awkward.

## Test plan

- [ ] `Validate PR title` workflow passes (`fix:` is conventional)
- [ ] `Label PR by convention` applies the `fix` label
- [ ] After merge, recover v2.0.9 on PyPI via a separate one-off (decide between bump-to-2.0.10, ad-hoc `workflow_dispatch`, or local upload)
- [ ] Next release end-to-end: `hatch version <rule>` → `git push --follow-tags` → `Generate changelog` → both `Release a new version` AND `Upload to PyPI` fan out and succeed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>